### PR TITLE
chore: remove accidental submodule and fix security-scan permissions

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "17 5 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- remove the accidental submodule entry from the repository root
- referenced CI checks can run with explicit read access

## Why
- the submodule link was accidentally introduced and not required for this project
- GitHub security workflows require explicit permissions in scoped runners

## Verification
-  directory removed from git index
- workflow file updated with an explicit permissions block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow security configurations for internal processes.
  * Removed internal repository management dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->